### PR TITLE
Add `__future__`, provide a way to switch the default solver factory

### DIFF
--- a/doc/OnlineDocs/developer_reference/future.rst
+++ b/doc/OnlineDocs/developer_reference/future.rst
@@ -1,0 +1,3 @@
+
+.. automodule:: pyomo.__future__
+   :noindex:

--- a/doc/OnlineDocs/developer_reference/index.rst
+++ b/doc/OnlineDocs/developer_reference/index.rst
@@ -12,4 +12,5 @@ scripts using Pyomo.
    config.rst
    deprecation.rst
    expressions/index.rst
+   future.rst
    solvers.rst

--- a/pyomo/__future__.py
+++ b/pyomo/__future__.py
@@ -1,7 +1,7 @@
 #  ___________________________________________________________________________
 #
 #  Pyomo: Python Optimization Modeling Objects
-#  Copyright (c) 2008-2022
+#  Copyright (c) 2008-2024
 #  National Technology and Engineering Solutions of Sandia, LLC
 #  Under the terms of Contract DE-NA0003525 with National Technology and
 #  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain

--- a/pyomo/__future__.py
+++ b/pyomo/__future__.py
@@ -43,9 +43,9 @@ def solver_factory(version=None):
     This allows users to query / set the current implementation of the
     SolverFactory that should be used throughout Pyomo.  Valid options are:
 
-      1: the original Pyomo SolverFactor
-      2: the SolverFactory from APPSI
-      3: the SolverFactory from pyomo.contrib.solver
+    - ``1``: the original Pyomo SolverFactor
+    - ``2``: the SolverFactory from APPSI
+    - ``3``: the SolverFactory from pyomo.contrib.solver
 
     The current active version can be obtained by calling the method
     with no arguments

--- a/pyomo/__future__.py
+++ b/pyomo/__future__.py
@@ -1,0 +1,69 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright (c) 2008-2022
+#  National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+import pyomo.environ as _environ
+
+
+def __getattr__(name):
+    if name in ('solver_factory_v1', 'solver_factory_v2', 'solver_factory_v3'):
+        return solver_factory(int(name[-1]))
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def solver_factory(version=None):
+    """Get (or set) the active implementation of the SolverFactory
+
+    This allows users to query / set the current implementation of the
+    SolverFactory that should be used throughout Pyomo.  Valid options are:
+    
+      1: the original Pyomo SolverFactor
+      2: the SolverFactory from APPSI
+      3: the SolverFactory from pyomo.contrib.solver
+
+    """
+    import pyomo.opt.base.solvers as _solvers
+    import pyomo.contrib.solver.factory as _contrib
+    import pyomo.contrib.appsi.base as _appsi
+    versions = {
+        1: _solvers.LegacySolverFactory,
+        2: _appsi.SolverFactory,
+        3: _contrib.SolverFactory,
+    }
+
+    current = getattr(solver_factory, '_active_version', None)
+    # First time through, _active_version is not defined.  Go look and
+    # see what it was initialized to in pyomo.environ
+    if current is None:
+        for ver, cls in versions.items():
+            if cls._cls is _environ.SolverFactory._cls:
+                solver_factory._active_version = ver
+                break
+        return solver_factory._active_version
+    #
+    # The user is just asking what the current SolverFactory is; tell them.
+    if version is None:
+        return solver_factory._active_version
+    #
+    # Update the current SolverFactory to be a shim around (shallow copy
+    # of) the new active factory
+    src = versions.get(version, None)
+    if version is not None:
+        solver_factory._active_version = version
+        for attr in ('_description', '_cls', '_doc'):
+            setattr(_environ.SolverFactory, attr, getattr(src, attr))
+    else:
+        raise ValueError(
+            "Invalid value for target solver factory version; expected {1, 2, 3}, "
+            f"received {version}"
+        )
+    return src
+
+solver_factory._active_version = solver_factory()

--- a/pyomo/__future__.py
+++ b/pyomo/__future__.py
@@ -12,15 +12,15 @@
 import pyomo.environ as _environ
 
 __doc__ = """
-Preview capabilities through `pyomo.__future__`
-===============================================
+Preview capabilities through ``pyomo.__future__``
+=================================================
 
 This module provides a uniform interface for gaining access to future
 ("preview") capabilities that are either slightly incompatible with the
 current official offering, or are still under development with the
 intent to replace the current offering.
 
-Currently supported `__future__` offerings include:
+Currently supported ``__future__`` offerings include:
 
 .. autosummary::
 

--- a/pyomo/__future__.py
+++ b/pyomo/__future__.py
@@ -11,6 +11,25 @@
 
 import pyomo.environ as _environ
 
+__doc__ = """
+Preview capabilities through `pyomo.__future__`
+===============================================
+
+This module provides a uniform interface for gaining access to future
+("preview") capabilities that are either slightly incompatible with the
+current official offering, or are still under development with the
+intent to replace the current offering.
+
+Currently supported `__future__` offerings include:
+
+.. autosummary::
+
+   solver_factory
+
+.. autofunction:: solver_factory
+
+"""
+
 
 def __getattr__(name):
     if name in ('solver_factory_v1', 'solver_factory_v2', 'solver_factory_v3'):
@@ -23,15 +42,39 @@ def solver_factory(version=None):
 
     This allows users to query / set the current implementation of the
     SolverFactory that should be used throughout Pyomo.  Valid options are:
-    
+
       1: the original Pyomo SolverFactor
       2: the SolverFactory from APPSI
       3: the SolverFactory from pyomo.contrib.solver
+
+    The current active version can be obtained by calling the method
+    with no arguments
+
+    .. doctest::
+
+        >>> from pyomo.__future__ import solver_factory
+        >>> solver_factory()
+        1
+
+    The active factory can be set either by passing the appropriate
+    version to this function:
+
+    .. doctest::
+
+        >>> solver_factory(3)
+        <pyomo.contrib.solver.factory.SolverFactoryClass object ...>
+
+    or by importing the "special" name:
+
+    .. doctest::
+
+        >>> from pyomo.__future__ import solver_factory_v3
 
     """
     import pyomo.opt.base.solvers as _solvers
     import pyomo.contrib.solver.factory as _contrib
     import pyomo.contrib.appsi.base as _appsi
+
     versions = {
         1: _solvers.LegacySolverFactory,
         2: _appsi.SolverFactory,
@@ -65,5 +108,6 @@ def solver_factory(version=None):
             f"received {version}"
         )
     return src
+
 
 solver_factory._active_version = solver_factory()

--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -1685,7 +1685,7 @@ class SolverFactoryClass(Factory):
             class LegacySolver(LegacySolverInterface, cls):
                 pass
 
-            LegacySolverFactory.register(name, doc)(LegacySolver)
+            LegacySolverFactory.register('appsi_' + name, doc)(LegacySolver)
 
             return cls
 

--- a/pyomo/contrib/appsi/plugins.py
+++ b/pyomo/contrib/appsi/plugins.py
@@ -9,15 +9,13 @@ def load():
     SolverFactory.register(
         name='gurobi', doc='Automated persistent interface to Gurobi'
     )(Gurobi)
-    SolverFactory.register(
-        name='cplex', doc='Automated persistent interface to Cplex'
-    )(Cplex)
-    SolverFactory.register(
-        name='ipopt', doc='Automated persistent interface to Ipopt'
-    )(Ipopt)
-    SolverFactory.register(
-        name='cbc', doc='Automated persistent interface to Cbc'
-    )(Cbc)
-    SolverFactory.register(
-        name='highs', doc='Automated persistent interface to Highs'
-    )(Highs)
+    SolverFactory.register(name='cplex', doc='Automated persistent interface to Cplex')(
+        Cplex
+    )
+    SolverFactory.register(name='ipopt', doc='Automated persistent interface to Ipopt')(
+        Ipopt
+    )
+    SolverFactory.register(name='cbc', doc='Automated persistent interface to Cbc')(Cbc)
+    SolverFactory.register(name='highs', doc='Automated persistent interface to Highs')(
+        Highs
+    )

--- a/pyomo/contrib/appsi/plugins.py
+++ b/pyomo/contrib/appsi/plugins.py
@@ -7,17 +7,17 @@ from .build import AppsiBuilder
 def load():
     ExtensionBuilderFactory.register('appsi')(AppsiBuilder)
     SolverFactory.register(
-        name='appsi_gurobi', doc='Automated persistent interface to Gurobi'
+        name='gurobi', doc='Automated persistent interface to Gurobi'
     )(Gurobi)
     SolverFactory.register(
-        name='appsi_cplex', doc='Automated persistent interface to Cplex'
+        name='cplex', doc='Automated persistent interface to Cplex'
     )(Cplex)
     SolverFactory.register(
-        name='appsi_ipopt', doc='Automated persistent interface to Ipopt'
+        name='ipopt', doc='Automated persistent interface to Ipopt'
     )(Ipopt)
     SolverFactory.register(
-        name='appsi_cbc', doc='Automated persistent interface to Cbc'
+        name='cbc', doc='Automated persistent interface to Cbc'
     )(Cbc)
     SolverFactory.register(
-        name='appsi_highs', doc='Automated persistent interface to Highs'
+        name='highs', doc='Automated persistent interface to Highs'
     )(Highs)

--- a/pyomo/contrib/solver/factory.py
+++ b/pyomo/contrib/solver/factory.py
@@ -10,7 +10,7 @@
 #  ___________________________________________________________________________
 
 
-from pyomo.opt.base import SolverFactory as LegacySolverFactory
+from pyomo.opt.base import LegacySolverFactory
 from pyomo.common.factory import Factory
 from pyomo.contrib.solver.base import LegacySolverWrapper
 

--- a/pyomo/contrib/solver/factory.py
+++ b/pyomo/contrib/solver/factory.py
@@ -10,7 +10,7 @@
 #  ___________________________________________________________________________
 
 
-from pyomo.opt.base import LegacySolverFactory
+from pyomo.opt.base.solvers import LegacySolverFactory
 from pyomo.common.factory import Factory
 from pyomo.contrib.solver.base import LegacySolverWrapper
 

--- a/pyomo/contrib/solver/factory.py
+++ b/pyomo/contrib/solver/factory.py
@@ -16,7 +16,10 @@ from pyomo.contrib.solver.base import LegacySolverWrapper
 
 
 class SolverFactoryClass(Factory):
-    def register(self, name, doc=None):
+    def register(self, name, legacy_name=None, doc=None):
+        if legacy_name is None:
+            legacy_name = name
+
         def decorator(cls):
             self._cls[name] = cls
             self._doc[name] = doc
@@ -24,7 +27,7 @@ class SolverFactoryClass(Factory):
             class LegacySolver(LegacySolverWrapper, cls):
                 pass
 
-            LegacySolverFactory.register(name, doc)(LegacySolver)
+            LegacySolverFactory.register(legacy_name, doc)(LegacySolver)
 
             return cls
 

--- a/pyomo/contrib/solver/plugins.py
+++ b/pyomo/contrib/solver/plugins.py
@@ -16,7 +16,9 @@ from .gurobi import Gurobi
 
 
 def load():
-    SolverFactory.register(name='ipopt_v2', doc='The IPOPT NLP solver (new interface)')(
-        ipopt
-    )
-    SolverFactory.register(name='gurobi_v2', doc='New interface to Gurobi')(Gurobi)
+    SolverFactory.register(
+        name='ipopt', legacy_name='ipopt_v2', doc='The IPOPT NLP solver (new interface)'
+    )(ipopt)
+    SolverFactory.register(
+        name='gurobi', legacy_name='gurobi_v2', doc='New interface to Gurobi'
+    )(Gurobi)

--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -181,7 +181,11 @@ class SolverFactoryClass(Factory):
         return opt
 
 
+LegacySolverFactory = SolverFactoryClass('solver type')
+
 SolverFactory = SolverFactoryClass('solver type')
+SolverFactory._cls = LegacySolverFactory._cls
+SolverFactory._doc = LegacySolverFactory._doc
 
 
 #


### PR DESCRIPTION
<!-- ##################################################################### -->
<!-- PLEASE READ BEFORE OPENING THIS PULL REQUEST -->

<!-- All changes must adhere to PEP8 standards as enforced by Black. -->
<!-- If your changes do NOT adhere, the test suite will fail. -->
<!-- Please read our Contributing guide for instructions on how to apply these standards. -->
<!-- Contributing Guide: https://pyomo.readthedocs.io/en/stable/contribution_guide.html -->
<!-- ##################################################################### -->

## Fixes # .

## Summary/Motivation:
This adds a "__future__" module to pyomo where we can collect utilities for accessing preview capabilities.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
